### PR TITLE
fix: create `~/.docker` directory in Docker images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,4 +9,6 @@ COPY dive /usr/local/bin/
 FROM scratch
 COPY --from=base / /
 
+RUN mkdir -p /root/.docker
+
 ENTRYPOINT ["/usr/local/bin/dive"]


### PR DESCRIPTION
Error:
```
❯ docker run -ti --rm  -v /var/run/docker.sock:/var/run/docker.sock joschi/dive:0.13.0-alpha.1 busybox:latest
Image Source: docker://busybox:latest
Extracting image from docker-engine... (this can take a while for large images)
> could not determine docker host: stat /root/.docker: no such file or directory
cannot fetch image
unable to parse docker host ``
```